### PR TITLE
Correct filepath on back.svg in Account.scss

### DIFF
--- a/src/Containers/Account/Account.scss
+++ b/src/Containers/Account/Account.scss
@@ -18,7 +18,7 @@ $blue-accent: #59DBE6;
   text-shadow: 0 0 1rem black;
   width: calc(100% - 1rem);
   .back-button {
-    background: url(../../images/back.svg);
+    background: url(../../Images/back.svg);
     filter: invert(80%);
     height: 2rem;
     width: 2rem;


### PR DESCRIPTION
## Description:

This PR addresses issue #`<NUMBER>`.

The changes made to the codebase in this PR:

* Change filepath on Account.scss from `../../images/back.svg` to `../../Images/back.svg`, as it was causing heroku build to fail.

## Requests for review

Areas of concern:

* Ensure that the back arrow is visible in Account.
